### PR TITLE
Adds api status GET method

### DIFF
--- a/mb-logging-api-server.js
+++ b/mb-logging-api-server.js
@@ -123,7 +123,7 @@ app.get('/api', function(req, res) {
   res.send(200, 'Message Broker Logging API (mb-logging-api). Available versions: v1 (/api/v1) See https://github.com/DoSomething/mb-logging-api for the related git repository.');
 });
 app.get('/api/v1', function(req, res) {
-  res.send(200, 'Message Broker Logging API (mb-logging-api). Version 1.x.x, see wiki () for documentation');
+  res.send(200, 'Message Broker Logging API (mb-logging-api). Version 1.x.x, see wiki (https://github.com/DoSomething/mb-logging-api/wiki) for documentation');
 });
 
 /**


### PR DESCRIPTION
Fixes #2 

GET /api returns the API name, a link to the related github repo and the available versions
GET /api/v1 returns the status v1 of the API
