### PR TITLE
Issue1 make endpoint names RESTful

### DIFF
--- a/lib/user-import-summary.js
+++ b/lib/user-import-summary.js
@@ -54,6 +54,12 @@ UserImportSummary.prototype.post = function(req, res) {
   if (this.request.body.skipped !== undefined) {
     addArgs.skipped = this.request.body.skipped;
   }
+  if (this.request.body.source !== undefined) {
+    addArgs.source = this.request.body.source;
+  }
+  if (this.request.body.type !== undefined) {
+    addArgs.log_type = this.request.body.type;
+  }
 
   var logEntry = new this.docModel(addArgs);
   logEntry.save(function(err) {
@@ -64,7 +70,7 @@ UserImportSummary.prototype.post = function(req, res) {
     // Added log entry to db
     dslogger.log('Save executed on: ' + addArgs + '. Raw response from mongo:');
     dslogger.log(addArgs);
-    return console.log("Created log entry.");
+    return console.log("Created summary log entry using UserImportSummary POST method.");
   });
 
   return res.send(logEntry);

--- a/mb-logging-api-server.js
+++ b/mb-logging-api-server.js
@@ -72,13 +72,20 @@ mongoose.connection.on('error', function(err) {
 
 var userImportModel;
 var userImportCollectionName = 'userimport-niche';
-var userImportSummaryModel;
-var userImportSummaryCollectionName = 'userimport-summary';
+var importSummaryModel;
+var importSummaryCollectionName = 'import-summary';
+
 mongoose.connection.once('open', function() {
 
   // User import logging schema for existing entries
   var userImportLoggingSchema = new mongoose.Schema({
     logged_date : { type: Date, default: Date.now },
+    source : {
+      type : String,
+      lowercase : 1,
+      trim : true,
+      enum: ['niche.com']
+    },
     phone : {
       number : { type : String, trim : true },
       status : { type : String, trim : true }
@@ -98,7 +105,7 @@ mongoose.connection.once('open', function() {
   userImportModel = mongoose.model(userImportCollectionName, userImportLoggingSchema);
 
   // User import logging schema for summary reports
-  var userImportSummarySchema = new mongoose.Schema({
+  var importSummarySchema = new mongoose.Schema({
     logged_date : { type: Date, default: Date.now },
     target_CSV_file : { type : String, trim : true },
     signup_count : { type : Number },
@@ -109,10 +116,16 @@ mongoose.connection.once('open', function() {
       trim : true,
       enum: ['niche.com']
     },
+    log_type : {
+      type : String,
+      lowercase : 1,
+      trim : true,
+      enum: ['user_import']
+    },
   });
-  userImportSummarySchema.set('autoIndex', false);
+  importSummarySchema.set('autoIndex', false);
   // Logging summary model
-  userImportSummaryModel = mongoose.model(userImportSummaryCollectionName, userImportSummarySchema);
+  importSummaryModel = mongoose.model(importSummaryCollectionName, importSummarySchema);
 
   console.log("Connection to Mongo (%s) succeeded! Ready to go...\n\n", mongoUri);
 });
@@ -173,7 +186,7 @@ app.post('/api/v1/imports/summaries', function(req, res) {
     dslogger.error('POST /api/v1/imports/summaries request. Type or source not specified or no target CSV file, signup count and skipped values specified.');
   }
   else {
-    var userImportSummary = new UserImportSummary(userImportSummaryModel);
+    var userImportSummary = new UserImportSummary(importSummaryModel);
     userImportSummary.post(req, res);
   }
 });


### PR DESCRIPTION
Fixes #1 
- adjusted endpoint paths to use plural nouns rather than verbs `/api/v1/imports`
- use http GET and POST methods to direct end points to load different classes rather than defining endpoints.
- add `source` and `type` to schema to abstract away from user specific collections.
- add supporting comments to explain endpoint use of parameters
