### PR TITLE
Adds acquired to phone log

### DIFF
--- a/mb-logging-api-server.js
+++ b/mb-logging-api-server.js
@@ -119,7 +119,8 @@ mongoose.connection.once('open', function() {
     },
     phone : {
       number : { type : String, trim : true },
-      status : { type : String, trim : true }
+      status : { type : String, trim : true },
+      acquired : { type: Date }
     },
     email : {
       address : { type : String, trim : true },


### PR DESCRIPTION
Fixes #12 

Adds acquired to phone and marks resolved solution for `email.acquired`. The date value returned from Mailchimp is in a Date format rather than the assumed timestamp even though the return field is called `timestamp`.
